### PR TITLE
refactor: remove react-router and use Next.js navigation

### DIFF
--- a/migration/portfolio_v2.5/src/Components/Footer/Footer.js
+++ b/migration/portfolio_v2.5/src/Components/Footer/Footer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Link from 'next/link'; // Replace react-router-dom imports
+import Link from 'next/link';
 import { Github, Linkedin, Twitter, Mail } from 'lucide-react';
 import './Footer.css';
 

--- a/migration/portfolio_v2.5/src/Components/Header/Header.js
+++ b/migration/portfolio_v2.5/src/Components/Header/Header.js
@@ -1,7 +1,7 @@
 "use client"; // The Header must be a client component to use context and handle clicks.
 
 import React, { useContext, useEffect } from 'react';
-import Link from 'next/link'; // Replace react-router-dom imports
+import Link from 'next/link';
 import { FolderOpen, User, Mail, Sun, Moon } from 'lucide-react'; // Import Mail, Sun, and Moon icons
 import CTAButton from '../CTAButton/CTAButton'; // Import CTAButton component
 import { ThemeContext } from '../../context/ThemeContext'; // Adjust path

--- a/migration/portfolio_v2.5/src/Components/Header/Header.test.js
+++ b/migration/portfolio_v2.5/src/Components/Header/Header.test.js
@@ -1,18 +1,14 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import mockRouter from '../../test-utils/mockRouter'
 import Header from './Header'
 
 describe('Header', () => {
   it('renders all navigation links and logo', () => {
     render(
-      <MemoryRouter
-        future={{
-          v7_startTransition: true,
-          v7_relativeSplatPath: true,
-        }}
-      >
+      <RouterContext.Provider value={mockRouter}>
         <Header theme="light" changeTheme={jest.fn()} />
-      </MemoryRouter>
+      </RouterContext.Provider>
     )
     // Logo/brand should be present
     expect(screen.getByText(/kw/i)).toBeInTheDocument()
@@ -24,14 +20,9 @@ describe('Header', () => {
 
   it('renders the theme toggle button', () => {
     render(
-      <MemoryRouter
-        future={{
-          v7_startTransition: true,
-          v7_relativeSplatPath: true,
-        }}
-      >
+      <RouterContext.Provider value={mockRouter}>
         <Header theme="dark" changeTheme={jest.fn()} />
-      </MemoryRouter>
+      </RouterContext.Provider>
     )
     expect(screen.getByRole('button', { name: /change theme/i })).toBeInTheDocument()
   })
@@ -39,14 +30,9 @@ describe('Header', () => {
   it('calls changeTheme with the next theme', () => {
     const changeTheme = jest.fn()
     render(
-      <MemoryRouter
-        future={{
-          v7_startTransition: true,
-          v7_relativeSplatPath: true,
-        }}
-      >
+      <RouterContext.Provider value={mockRouter}>
         <Header theme="dark" changeTheme={changeTheme} />
-      </MemoryRouter>
+      </RouterContext.Provider>
     )
     screen.getByRole('button', { name: /change theme/i }).click()
     expect(changeTheme).toHaveBeenCalledWith('light')

--- a/migration/portfolio_v2.5/src/Pages/Resources/Resources.test.js
+++ b/migration/portfolio_v2.5/src/Pages/Resources/Resources.test.js
@@ -1,5 +1,6 @@
 import { render, screen, act } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import mockRouter from '../../test-utils/mockRouter'
 import { HelmetProvider } from 'react-helmet-async'
 import Header from '../../Components/Header/Header'
 import Resources from './Resources'
@@ -25,14 +26,9 @@ describe('Resources Page', () => {
   it('is not rendered or linked in the navigation', () => {
     render(
       <HelmetProvider>
-        <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+        <RouterContext.Provider value={mockRouter}>
           <Header theme="light" changeTheme={jest.fn()} />
-        </MemoryRouter>
+        </RouterContext.Provider>
       </HelmetProvider>
     )
     expect(screen.queryByText(/resources/i)).not.toBeInTheDocument()

--- a/migration/portfolio_v2.5/src/_tests_/About.test.js
+++ b/migration/portfolio_v2.5/src/_tests_/About.test.js
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { act } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import mockRouter from '../test-utils/mockRouter'
 import { HelmetProvider } from 'react-helmet-async'; // Import HelmetProvider
 import About from './About'
 
@@ -8,15 +9,10 @@ describe('About', () => {
   it('renders the About page with key sections', () => {
     act(() => {
       render(
-        <HelmetProvider> {/* Wrap with HelmetProvider */}
-          <MemoryRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+        <HelmetProvider>
+          <RouterContext.Provider value={mockRouter}>
             <About />
-          </MemoryRouter>
+          </RouterContext.Provider>
         </HelmetProvider>
       )
     })
@@ -29,15 +25,10 @@ describe('About', () => {
   it('renders the Start a Project button', () => {
     act(() => {
       render(
-        <HelmetProvider> {/* Wrap with HelmetProvider */}
-          <MemoryRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+        <HelmetProvider>
+          <RouterContext.Provider value={mockRouter}>
             <About />
-          </MemoryRouter>
+          </RouterContext.Provider>
         </HelmetProvider>
       )
     })
@@ -47,15 +38,10 @@ describe('About', () => {
   it('opens the modal with contact form when Start a Project is clicked', () => {
     act(() => {
       render(
-        <HelmetProvider> {/* Wrap with HelmetProvider */}
-          <MemoryRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+        <HelmetProvider>
+          <RouterContext.Provider value={mockRouter}>
             <About />
-          </MemoryRouter>
+          </RouterContext.Provider>
         </HelmetProvider>
       )
     })
@@ -72,15 +58,10 @@ describe('About', () => {
   it('closes the modal when overlay is clicked', () => {
     act(() => {
       render(
-        <HelmetProvider> {/* Wrap with HelmetProvider */}
-          <MemoryRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+        <HelmetProvider>
+          <RouterContext.Provider value={mockRouter}>
             <About />
-          </MemoryRouter>
+          </RouterContext.Provider>
         </HelmetProvider>
       )
     })
@@ -100,15 +81,10 @@ describe('About', () => {
   it('closes the modal when close button is clicked', () => {
     act(() => {
       render(
-        <HelmetProvider> {/* Wrap with HelmetProvider */}
-          <MemoryRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+        <HelmetProvider>
+          <RouterContext.Provider value={mockRouter}>
             <About />
-          </MemoryRouter>
+          </RouterContext.Provider>
         </HelmetProvider>
       )
     })

--- a/migration/portfolio_v2.5/src/_tests_/App.test.js
+++ b/migration/portfolio_v2.5/src/_tests_/App.test.js
@@ -2,7 +2,8 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { act } from 'react'
 import App from '../App/App'
-import { MemoryRouter } from 'react-router-dom';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+import mockRouter from '../test-utils/mockRouter';
 import { HelmetProvider } from 'react-helmet-async';
 
 it('renders about link', () => {
@@ -10,14 +11,9 @@ it('renders about link', () => {
   act(() => {
     ({ getAllByText } = render(
       <HelmetProvider>
-        <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+        <RouterContext.Provider value={mockRouter}>
           <App />
-        </MemoryRouter>
+        </RouterContext.Provider>
       </HelmetProvider>
     ));
   });

--- a/migration/portfolio_v2.5/src/_tests_/Contact.test.js
+++ b/migration/portfolio_v2.5/src/_tests_/Contact.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { act } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import mockRouter from '../test-utils/mockRouter'
 import Contact from './Contact'
 import userEvent from '@testing-library/user-event';
 import * as emailjs from '@emailjs/browser';
@@ -11,14 +12,9 @@ describe('Contact', () => {
   it('renders the Contact page with key sections', () => {
     act(() => {
       render(
-        <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+        <RouterContext.Provider value={mockRouter}>
           <Contact />
-        </MemoryRouter>
+        </RouterContext.Provider>
       )
     })
     expect(screen.getByText(/Let's Connect!/i)).toBeInTheDocument()
@@ -27,14 +23,9 @@ describe('Contact', () => {
 
   it('shows validation errors for empty fields', async () => {
     render(
-      <MemoryRouter
-        future={{
-          v7_startTransition: true,
-          v7_relativeSplatPath: true,
-        }}
-      >
+      <RouterContext.Provider value={mockRouter}>
         <Contact />
-      </MemoryRouter>
+      </RouterContext.Provider>
     );
     
     await act(async () => {
@@ -48,14 +39,9 @@ describe('Contact', () => {
 
   it('shows validation error for invalid email', async () => {
     render(
-      <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+      <RouterContext.Provider value={mockRouter}>
         <Contact />
-      </MemoryRouter>
+      </RouterContext.Provider>
     );
     
     await act(async () => {
@@ -71,14 +57,9 @@ describe('Contact', () => {
   it('submits the form and shows success message on EmailJS success', async () => {
     emailjs.send.mockResolvedValueOnce({ status: 200 });
     render(
-      <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+      <RouterContext.Provider value={mockRouter}>
         <Contact />
-      </MemoryRouter>
+      </RouterContext.Provider>
     );
     
     await act(async () => {
@@ -94,14 +75,9 @@ describe('Contact', () => {
   it('shows error message on EmailJS failure', async () => {
     emailjs.send.mockRejectedValueOnce(new Error('Email failed'));
     render(
-      <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+      <RouterContext.Provider value={mockRouter}>
         <Contact />
-      </MemoryRouter>
+      </RouterContext.Provider>
     );
     
     await act(async () => {

--- a/migration/portfolio_v2.5/src/_tests_/Homepage.test.js
+++ b/migration/portfolio_v2.5/src/_tests_/Homepage.test.js
@@ -1,20 +1,16 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import mockRouter from '../test-utils/mockRouter'
 import { HelmetProvider } from 'react-helmet-async'; // Import HelmetProvider
 import Homepage from '../app/Home/Homepage'
 
 describe('Homepage', () => {
   it('renders hero section with headline and actions', () => {
     render(
-      <HelmetProvider> {/* Wrap with HelmetProvider */}
-        <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+      <HelmetProvider>
+        <RouterContext.Provider value={mockRouter}>
           <Homepage />
-        </MemoryRouter>
+        </RouterContext.Provider>
       </HelmetProvider>
     )
     expect(screen.getByRole('heading', { level: 1, name: /user-centric/i })).toBeInTheDocument()
@@ -32,15 +28,10 @@ describe('Homepage', () => {
 
   it('renders featured projects section and at least one project card', () => {
     render(
-      <HelmetProvider> {/* Wrap with HelmetProvider */}
-        <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+      <HelmetProvider>
+        <RouterContext.Provider value={mockRouter}>
           <Homepage />
-        </MemoryRouter>
+        </RouterContext.Provider>
       </HelmetProvider>
     )
     expect(screen.getByRole('heading', { level: 2, name: /featured projects/i })).toBeInTheDocument()
@@ -52,15 +43,10 @@ describe('Homepage', () => {
 
   it('renders homepage CTA section with correct text and button', () => {
     render(
-      <HelmetProvider> {/* Wrap with HelmetProvider */}
-        <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+      <HelmetProvider>
+        <RouterContext.Provider value={mockRouter}>
           <Homepage />
-        </MemoryRouter>
+        </RouterContext.Provider>
       </HelmetProvider>
     )
     expect(screen.getByRole('heading', { level: 2, name: /ready to build/i })).toBeInTheDocument()

--- a/migration/portfolio_v2.5/src/_tests_/Projects.test.js
+++ b/migration/portfolio_v2.5/src/_tests_/Projects.test.js
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { act } from 'react'
 import '@testing-library/jest-dom'
-import { MemoryRouter } from 'react-router-dom'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import mockRouter from '../test-utils/mockRouter'
 import { HelmetProvider } from 'react-helmet-async';
 import Projects from '../app/Projects/Projects'
 
@@ -24,14 +25,9 @@ describe('Projects', () => {
   const renderProjects = () => {
     render(
       <HelmetProvider>
-        <MemoryRouter
-          future={{
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+        <RouterContext.Provider value={mockRouter}>
           <Projects />
-        </MemoryRouter>
+        </RouterContext.Provider>
       </HelmetProvider>
     );
   };

--- a/migration/portfolio_v2.5/src/app/App.test.js
+++ b/migration/portfolio_v2.5/src/app/App.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { act } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import mockRouter from '../test-utils/mockRouter'
 import { HelmetProvider } from 'react-helmet-async'; // Import HelmetProvider
 import App from './App'
 
@@ -8,15 +9,10 @@ describe('App', () => {
   it('renders without crashing and shows header', () => {
     act(() => {
       render(
-        <HelmetProvider> {/* Add HelmetProvider here */}
-          <MemoryRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+        <HelmetProvider>
+          <RouterContext.Provider value={mockRouter}>
             <App />
-          </MemoryRouter>
+          </RouterContext.Provider>
         </HelmetProvider>
       )
     })

--- a/migration/portfolio_v2.5/src/app/not-found/page.js
+++ b/migration/portfolio_v2.5/src/app/not-found/page.js
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 import { Home, AlertCircle } from 'lucide-react';
 import Head from 'next/head';
 import '../_Pages.css';
@@ -50,7 +50,7 @@ function NotFound() {
           
           <nav aria-label="Error page navigation" style={{ display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
             <Link 
-              to="/" 
+              href="/" 
               className="cta-btn" 
               style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}
               aria-label="Return to homepage"
@@ -60,7 +60,7 @@ function NotFound() {
             </Link>
             
             <Link 
-              to="/projects" 
+              href="/projects" 
               className="cta-btn" 
               style={{ background: 'transparent', color: 'var(--accent-color, #007acc)', border: '2px solid var(--accent-color, #007acc)' }}
               aria-label="View my design projects"
@@ -69,7 +69,7 @@ function NotFound() {
             </Link>
             
             <Link 
-              to="/contact" 
+              href="/contact" 
               className="cta-btn" 
               style={{ background: 'transparent', color: 'var(--accent-color, #007acc)', border: '2px solid var(--accent-color, #007acc)' }}
               aria-label="Contact me for help"
@@ -89,7 +89,7 @@ function NotFound() {
             role="list"
           >
             <Link 
-              to="/" 
+              href="/" 
               style={{ 
                 padding: '1rem', 
                 background: 'var(--card-background, #fff)', 
@@ -115,7 +115,7 @@ function NotFound() {
             </Link>
             
             <Link 
-              to="/about" 
+              href="/about" 
               style={{ 
                 padding: '1rem', 
                 background: 'var(--card-background, #fff)', 
@@ -141,7 +141,7 @@ function NotFound() {
             </Link>
             
             <Link 
-              to="/projects" 
+              href="/projects" 
               style={{ 
                 padding: '1rem', 
                 background: 'var(--card-background, #fff)', 
@@ -167,7 +167,7 @@ function NotFound() {
             </Link>
             
             <Link 
-              to="/contact" 
+              href="/contact" 
               style={{ 
                 padding: '1rem', 
                 background: 'var(--card-background, #fff)', 

--- a/migration/portfolio_v2.5/src/index.js
+++ b/migration/portfolio_v2.5/src/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App/App";
 import reportWebVitals from "./_tests_/reportWebVitals";
@@ -10,14 +9,7 @@ const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <HelmetProvider>
-      <BrowserRouter
-        future={{
-          v7_startTransition: true,
-          v7_relativeSplatPath: true,
-        }}
-      >
-        <App />
-      </BrowserRouter>
+      <App />
     </HelmetProvider>
   </React.StrictMode>
 );

--- a/migration/portfolio_v2.5/src/index.test.js
+++ b/migration/portfolio_v2.5/src/index.test.js
@@ -1,22 +1,18 @@
 import { render } from '@testing-library/react'
 import { act } from 'react'
 import App from './App/App'
-import { MemoryRouter } from 'react-router-dom'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import mockRouter from './test-utils/mockRouter'
 import { HelmetProvider } from 'react-helmet-async'; // Import HelmetProvider
 
 describe('index.js', () => {
   it('renders App without crashing', () => {
     act(() => {
       render(
-        <HelmetProvider> {/* Add HelmetProvider here */}
-          <MemoryRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+        <HelmetProvider>
+          <RouterContext.Provider value={mockRouter}>
             <App />
-          </MemoryRouter>
+          </RouterContext.Provider>
         </HelmetProvider>
       )
     })

--- a/migration/portfolio_v2.5/src/test-utils/mockRouter.js
+++ b/migration/portfolio_v2.5/src/test-utils/mockRouter.js
@@ -1,0 +1,8 @@
+export default {
+  push: jest.fn(),
+  replace: jest.fn(),
+  prefetch: jest.fn().mockResolvedValue(undefined),
+  pathname: '/',
+  query: {},
+  asPath: '/',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^2.0.5",
-        "react-router-dom": "^6.30.1",
         "react-scripts": "^5.0.1",
         "scheduler": "^0.26.0",
         "schema-utils": "^4.3.0",
@@ -3930,14 +3929,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -17451,36 +17442,6 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
-      "dependencies": {
-        "@remix-run/router": "1.23.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
-      "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.5",
-    "react-router-dom": "^6.30.1",
     "react-scripts": "^5.0.1",
     "scheduler": "^0.26.0",
     "schema-utils": "^4.3.0",


### PR DESCRIPTION
## Summary
- remove react-router-dom dependency
- switch NotFound and entry point to Next.js routing helpers
- mock Next router in tests instead of using MemoryRouter

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689d8809fa9c8333919cfc3d924ffcde