### PR TITLE
refactor: use next/image in app

### DIFF
--- a/migration/portfolio_v2.5/next.config.ts
+++ b/migration/portfolio_v2.5/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    domains: ["randomuser.me"],
+  },
 };
 
 export default nextConfig;

--- a/migration/portfolio_v2.5/src/app/About/page.js
+++ b/migration/portfolio_v2.5/src/app/About/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-const metadata = {
+export const metadata = {
   title: "About Kainen White",
   description: "Learn more about Kainen White, a product and UX designer creating user-centered digital experiences."
 };
@@ -128,7 +128,14 @@ function About() {
         <div className="services-grid" role="list">
           <article className="service-card" role="listitem">
             <div className="service-icon">
-              <img className="icon" src={designthinking} alt="" loading="lazy" aria-hidden="true" />
+              <Image
+                className="icon"
+                src={designthinking}
+                alt="Design thinking icon"
+                width={100}
+                height={100}
+                loading="lazy"
+              />
             </div>
             <h3>UX/UI Design</h3>
             <p>User research, wireframing, prototyping, and visual design that creates intuitive and engaging experiences.</p>
@@ -142,7 +149,14 @@ function About() {
           
           <article className="service-card" role="listitem">
             <div className="service-icon">
-              <img className="icon" src={dev} alt="" loading="lazy" aria-hidden="true" />
+              <Image
+                className="icon"
+                src={dev}
+                alt="Development icon"
+                width={100}
+                height={100}
+                loading="lazy"
+              />
             </div>
             <h3>Frontend Development</h3>
             <p>Responsive, accessible websites and applications built with modern technologies and best practices.</p>
@@ -156,7 +170,14 @@ function About() {
           
           <article className="service-card" role="listitem">
             <div className="service-icon">
-              <img className="icon" src={design} alt="" loading="lazy" aria-hidden="true" />
+              <Image
+                className="icon"
+                src={design}
+                alt="Design icon"
+                width={100}
+                height={100}
+                loading="lazy"
+              />
             </div>
             <h3>Design Consultation</h3>
             <p>Strategic guidance to improve your digital presence and user experience through expert analysis and recommendations.</p>

--- a/migration/portfolio_v2.5/src/app/Projects/[slug]/page.js
+++ b/migration/portfolio_v2.5/src/app/Projects/[slug]/page.js
@@ -5,9 +5,9 @@ import { useRouter, usePathname } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import SEO from '../../../Components/SEO/SEO';
 import MetricsDisplay from '../../../Components/MetricsDisplay/MetricsDisplay';
-import { notFound } from 'next/navigation';
 import { getProjectBySlug } from '../../../Data/projects';
 import './CaseStudy.css';
+import Image from 'next/image';
 
 // Helper function to render list items with proper accessibility
 const renderListItems = (items, type) => {
@@ -39,11 +39,13 @@ const renderTestimonial = (testimonial) => {
         <p>&ldquo;{testimonial.quote}&rdquo;</p>
         <footer className="testimonial-client">
           {testimonial.photo && (
-            <img 
-              src={testimonial.photo} 
+            <Image
+              src={testimonial.photo}
               alt={`${testimonial.name || testimonial.author}, ${testimonial.title} at ${testimonial.company}`}
-              className="testimonial-photo" 
-              loading="lazy" 
+              className="testimonial-photo"
+              width={50}
+              height={50}
+              loading="lazy"
             />
           )}
           <div className="testimonial-info">
@@ -214,9 +216,11 @@ export default function CaseStudyPage({ params }) {
         <h1 id="case-study-title" tabIndex={-1}>{title}</h1>
         {(images && images[0]) || image ? (
           <figure className="case-study-image">
-            <img 
-              src={(images && images[0]) || image} 
-              alt={`Main showcase for ${title} project`} 
+            <Image
+              src={(images && images[0]) || image}
+              alt={`Main showcase for ${title} project`}
+              width={800}
+              height={600}
               loading="lazy"
             />
           </figure>
@@ -333,11 +337,13 @@ export default function CaseStudyPage({ params }) {
                 <p>&ldquo;{testimonialItem.quote}&rdquo;</p>
                 <footer>
                   {testimonialItem.photo && (
-                    <img 
-                      src={testimonialItem.photo} 
-                      alt={`${testimonialItem.name || testimonialItem.author}, ${testimonialItem.title}`} 
-                      className="testimonial-photo" 
-                      loading="lazy" 
+                    <Image
+                      src={testimonialItem.photo}
+                      alt={`${testimonialItem.name || testimonialItem.author}, ${testimonialItem.title}`}
+                      className="testimonial-photo"
+                      width={50}
+                      height={50}
+                      loading="lazy"
                     />
                   )}
                   <cite>
@@ -404,18 +410,22 @@ export default function CaseStudyPage({ params }) {
           <h2 id="gallery-heading">Project Gallery</h2>
           <div className="gallery-grid" aria-label="Project screenshots gallery">
             {images && images.length > 1 && images.slice(1).map((imageUrl, index) => (
-              <img 
-                key={index} 
-                src={imageUrl} 
-                alt={`${title} screenshot ${index + 1}`} 
-                loading="lazy" 
+              <Image
+                key={index}
+                src={imageUrl}
+                alt={`${title} screenshot ${index + 1}`}
+                width={800}
+                height={600}
+                loading="lazy"
               />
             ))}
             {galleryImages && galleryImages.map((imageUrl, index) => (
-              <img 
-                key={index} 
-                src={imageUrl} 
-                alt={`${title} screenshot ${index + 1}`} 
+              <Image
+                key={index}
+                src={imageUrl}
+                alt={`${title} screenshot ${index + 1}`}
+                width={800}
+                height={600}
                 loading="lazy"
               />
             ))}

--- a/migration/portfolio_v2.5/src/app/page.tsx
+++ b/migration/portfolio_v2.5/src/app/page.tsx
@@ -9,7 +9,7 @@ import { getFeaturedProjects } from "../Data/projects";
 import { Sparkle, FolderOpen, Handshake, Quote } from "lucide-react";
 import { testimonials } from "../Data/testimonials";
 import { portfolioMetrics } from "../Data/portfolioMetrics";
-import themeStyles from "../Theme/themeStyles"; // If needed for styling
+import Image from "next/image";
 
 export const metadata: Metadata = {
   title: "Kainen White | Product & UX Designer",
@@ -188,10 +188,12 @@ export default function HomePage() {
         >
           {testimonials.map((t, i) => (
             <article key={i} className="testimonial-card" role="listitem">
-              <img
+              <Image
                 src={t.photo}
                 alt={`${t.name}, ${t.title} at ${t.company}`}
                 className="testimonial-photo"
+                width={50}
+                height={50}
                 loading="lazy"
               />
               <blockquote className="quote">&ldquo;{t.quote}&rdquo;</blockquote>


### PR DESCRIPTION
## Summary
- replace `<img>` tags in app pages with `next/image`
- add explicit dimensions and alt text for images
- allow `randomuser.me` domain for external images

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689d880c63a0833384798c7bc29b8d23