### PR TITLE
feat: add accessibility testing to nextjs v2.5

### DIFF
--- a/.github/workflows/accessibility-testing.yml
+++ b/.github/workflows/accessibility-testing.yml
@@ -22,12 +22,15 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        working-directory: migration/portfolio_v2.5
 
       - name: Build the application
         run: npm run build
+        working-directory: migration/portfolio_v2.5
 
       - name: Start the application
         run: npm start &
+        working-directory: migration/portfolio_v2.5
         env:
           CI: true
 
@@ -35,24 +38,25 @@ jobs:
         run: |
           echo "Waiting for application to start..."
           npx wait-on http://localhost:3000 --timeout 60000
+        working-directory: migration/portfolio_v2.5
         
       - name: Install accessibility testing tools
         run: |
           npm install -g pa11y lighthouse
           npm install --save-dev playwright @axe-core/playwright
           npx playwright install chromium
+        working-directory: migration/portfolio_v2.5
 
       - name: Run accessibility tests
-        run: |
-          chmod +x ./test-accessibility.sh
-          ./test-accessibility.sh
+        run: npm run test:accessibility
+        working-directory: migration/portfolio_v2.5
 
       - name: Archive accessibility test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: accessibility-test-results
-          path: accessibility-test-results/
+          path: migration/portfolio_v2.5/accessibility-test-results/
           retention-days: 30
 
       - name: Check for accessibility violations
@@ -80,6 +84,7 @@ jobs:
             echo "❌ axe test failed"
             exit 1
           fi
+        working-directory: migration/portfolio_v2.5
 
       - name: Comment PR with results
         if: github.event_name == 'pull_request'
@@ -90,7 +95,7 @@ jobs:
             const path = require('path');
             
             try {
-              const resultsDir = 'accessibility-test-results';
+              const resultsDir = 'migration/portfolio_v2.5/accessibility-test-results';
               let comment = '## 🔍 Accessibility Test Results\n\n';
               
               // Check for violations in axe results

--- a/migration/portfolio_v2.5/ACCESSIBILITY_AUTOMATION_GUIDE.md
+++ b/migration/portfolio_v2.5/ACCESSIBILITY_AUTOMATION_GUIDE.md
@@ -1,0 +1,279 @@
+# Accessibility Testing Automation - Developer Guide
+
+## 🎯 Overview
+
+This portfolio website now includes fully automated accessibility testing integrated into the development workflow. The automation ensures WCAG 2.1 AA compliance is maintained throughout the development process.
+
+## 🚀 Quick Start
+
+### Initial Setup (One-time)
+```bash
+# Run the automated setup script
+./setup-accessibility-automation.sh
+```
+
+### Daily Development Workflow
+```bash
+# 1. Start development server
+npm start
+
+# 2. Make your changes
+# ... code changes ...
+
+# 3. Commit (automated pre-commit testing)
+git add .
+git commit -m "Your commit message"
+# → Pre-commit hook runs quick accessibility check
+
+# 4. Before pushing, run full tests (optional but recommended)
+npm run test:accessibility
+
+# 5. Push to trigger CI/CD
+git push origin your-branch
+# → GitHub Actions runs comprehensive accessibility tests
+```
+
+## 🧪 Testing Commands
+
+### Available npm Scripts
+```bash
+# Full accessibility test suite (comprehensive)
+npm run test:accessibility
+
+# Shorthand version
+npm run test:a11y
+
+# Pre-commit accessibility validation
+npm run precommit:accessibility
+```
+
+### Direct Script Execution
+```bash
+# Run the comprehensive test script directly
+./test-accessibility.sh
+
+# Run only specific tool tests
+pa11y http://localhost:3000
+lighthouse http://localhost:3000 --only-categories=accessibility
+```
+
+## 🔄 Automated Testing Workflow
+
+### Pre-commit Testing
+**Triggers**: Every `git commit`
+**Coverage**: Quick homepage accessibility check
+**Tools**: pa11y
+**Time**: ~10 seconds
+**Behavior**:
+- ✅ Pass: Allows commit if no violations
+- ❌ Fail: Blocks commit with violation details
+- ⚠️ Skip: If dev server not running (warns but allows commit)
+
+### CI/CD Pipeline Testing  
+**Triggers**: Push to main/develop, Pull Requests
+**Coverage**: All pages (home, about, projects, contact, case studies)
+**Tools**: pa11y, Lighthouse, axe-core
+**Time**: ~3-5 minutes
+**Artifacts**: Test reports saved for 30 days
+
+### Automated PR Comments
+When you create a pull request, the CI/CD system automatically:
+- Runs comprehensive accessibility tests
+- Posts results as a PR comment
+- Shows pass/fail status and violation count
+- Links to detailed test reports
+
+## 📊 Understanding Test Results
+
+### Test Output Files
+After running tests, check `accessibility-test-results/`:
+```
+accessibility-test-results/
+├── accessibility-summary.html      # Overview of all tests
+├── pa11y-home.html                # pa11y detailed reports
+├── lighthouse-home.report.html    # Lighthouse reports  
+├── axe-home.html                  # axe-core reports
+└── ... (one set per page tested)
+```
+
+### Interpreting Results
+
+#### ✅ Success Indicators
+- **0 violations** across all tools
+- **Green checkmarks** in summary report
+- **100% scores** in Lighthouse accessibility audit
+- **Build passes** in GitHub Actions
+
+#### ❌ Failure Indicators
+- **Any violations** found by any tool
+- **Red error messages** in terminal output
+- **Failed build status** in GitHub
+- **Specific violation details** in generated reports
+
+### Common Violations and Fixes
+
+#### Color Contrast Issues
+```css
+/* ❌ Insufficient contrast */
+color: #999999; /* 2.85:1 ratio */
+
+/* ✅ WCAG AA compliant */
+color: #666666; /* 4.54:1 ratio */
+```
+
+#### Missing Alt Text
+```jsx
+{/* ❌ Missing alt text */}
+<img src="example.jpg" />
+
+{/* ✅ Descriptive alt text */}
+<img src="example.jpg" alt="User interface showing dashboard analytics" />
+```
+
+#### Keyboard Navigation
+```jsx
+{/* ❌ Missing keyboard support */}
+<div onClick={handleClick}>Click me</div>
+
+{/* ✅ Proper button with keyboard support */}
+<button onClick={handleClick}>Click me</button>
+```
+
+## 🛠️ Troubleshooting
+
+### Pre-commit Hook Issues
+
+**Problem**: Pre-commit hook fails with "Development server not running"
+```bash
+# Solution: Start the development server
+npm start
+# Then try committing again
+```
+
+**Problem**: Pre-commit hook finds violations
+```bash
+# Solution: Fix the violations before committing
+npm run test:accessibility  # Get detailed report
+# Fix issues, then commit again
+```
+
+**Problem**: Need to commit urgently without accessibility testing
+```bash
+# Emergency bypass (use sparingly)
+git commit --no-verify -m "Emergency commit"
+# Note: CI/CD will still catch violations
+```
+
+### CI/CD Pipeline Issues
+
+**Problem**: GitHub Actions workflow fails
+1. Check the Actions tab in your GitHub repository
+2. Review the "Run accessibility tests" step output
+3. Download artifacts to see detailed test reports
+4. Fix violations and push again
+
+**Problem**: False positives or tool errors
+1. Run tests locally: `npm run test:accessibility`
+2. Compare local vs CI results
+3. Check tool versions and configurations
+4. Update dependencies if needed
+
+### Local Testing Issues
+
+**Problem**: "Command not found" errors
+```bash
+# Install missing global tools
+npm install -g pa11y lighthouse
+
+# Install project dependencies
+npm install
+```
+
+**Problem**: Playwright browser issues
+```bash
+# Reinstall Playwright browsers
+npx playwright install chromium
+```
+
+**Problem**: Port conflicts
+```bash
+# Ensure development server is on port 3000
+npm start
+# Check with: curl http://localhost:3000
+```
+
+## 🔧 Customization
+
+### Modifying Test Coverage
+Edit `accessibility-test-config.js` to add/remove pages:
+```javascript
+urls: [
+  'http://localhost:3000',
+  'http://localhost:3000/about',
+  'http://localhost:3000/new-page',  // Add new pages here
+  // ... existing URLs
+]
+```
+
+### Adjusting Test Standards
+In `accessibility-test-config.js`:
+```javascript
+pa11y: {
+  standard: 'WCAG2AA',  // Can be WCAG2A, WCAG2AA, or WCAG2AAA
+  // ... other options
+}
+```
+
+### Modifying GitHub Actions
+Edit `.github/workflows/accessibility-testing.yml` to:
+- Change trigger conditions
+- Modify test execution steps
+- Adjust artifact retention
+- Customize PR comments
+
+## 📈 Best Practices
+
+### Development Workflow
+1. **Always run development server** during development
+2. **Test early and often** with `npm run test:accessibility`
+3. **Fix violations immediately** rather than accumulating them
+4. **Review test reports** to understand violation context
+5. **Use meaningful commit messages** when fixing accessibility issues
+
+### Code Review Process
+1. **Check PR comments** for automated test results
+2. **Review accessibility artifacts** for detailed analysis
+3. **Test manually** with keyboard navigation
+4. **Verify color contrast** for new UI elements
+5. **Ensure semantic HTML** in new components
+
+### Performance Considerations
+- **Pre-commit tests are lightweight** (homepage only)
+- **Full CI/CD tests are comprehensive** but run in parallel
+- **Local testing** can be resource-intensive
+- **Consider running full tests** before major commits
+
+## 📚 Additional Resources
+
+### Documentation
+- [ACCESSIBILITY_MAINTENANCE_GUIDE.md](./ACCESSIBILITY_MAINTENANCE_GUIDE.md) - Ongoing maintenance procedures
+- [ACCESSIBILITY_TESTING_CHECKLIST.md](./ACCESSIBILITY_TESTING_CHECKLIST.md) - Manual testing checklist
+- [ACCESSIBILITY_STATEMENT.md](./ACCESSIBILITY_STATEMENT.md) - Public accessibility commitment
+
+### External Resources
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
+- [WebAIM Accessibility Guidelines](https://webaim.org/)
+- [pa11y Documentation](https://github.com/pa11y/pa11y)
+- [Lighthouse Accessibility Audit](https://developers.google.com/web/tools/lighthouse)
+
+### Getting Help
+- **GitHub Issues**: Report automation problems
+- **Test Reports**: Check detailed violation information
+- **Developer Console**: Use browser dev tools for live testing
+- **WebAIM Resources**: Comprehensive accessibility guidance
+
+---
+
+**Last Updated**: June 15, 2025  
+**Version**: 1.0  
+**Maintained by**: Development Team

--- a/migration/portfolio_v2.5/ACCESSIBILITY_MAINTENANCE_GUIDE.md
+++ b/migration/portfolio_v2.5/ACCESSIBILITY_MAINTENANCE_GUIDE.md
@@ -1,0 +1,375 @@
+# Accessibility Maintenance Guide
+
+## Overview
+This guide ensures the portfolio website maintains WCAG 2.1 AA compliance over time. It provides procedures for ongoing accessibility maintenance, testing schedules, and issue resolution workflows.
+
+## Maintenance Schedule
+
+### Daily (Development Phase)
+- [ ] **Automated Testing**: Run accessibility tests on any code changes
+- [ ] **Focus Indicators**: Verify focus visibility on new interactive elements
+- [ ] **Color Contrast**: Check contrast ratios for any new color combinations
+
+### Weekly
+- [ ] **Quick Navigation Test**: 5-minute keyboard navigation spot check
+- [ ] **New Content Review**: Ensure any new content meets accessibility standards
+- [ ] **Image Alt Text**: Verify all new images have appropriate alt text
+
+### Monthly
+- [ ] **Full Automated Audit**: Run complete pa11y and Lighthouse testing suite
+- [ ] **Browser Compatibility**: Test accessibility features across supported browsers
+- [ ] **Mobile Accessibility**: Verify touch targets and mobile navigation
+
+### Quarterly
+- [ ] **Comprehensive Manual Testing**: Complete accessibility testing checklist
+- [ ] **User Feedback Review**: Address any accessibility feedback received
+- [ ] **Documentation Updates**: Update accessibility statement and guides
+- [ ] **Technology Updates**: Review and update accessibility testing tools
+
+### Annually
+- [ ] **Standards Review**: Check for updates to WCAG guidelines
+- [ ] **Third-Party Audit**: Consider professional accessibility audit
+- [ ] **Training Update**: Refresh team knowledge on accessibility best practices
+
+## Development Workflow Integration
+
+### Automated Testing Setup
+The portfolio now includes comprehensive automated accessibility testing integrated into the development workflow:
+
+#### CI/CD Pipeline
+```yaml
+# GitHub Actions automatically run on:
+- Push to main/develop branches
+- Pull requests to main/develop
+- Manual workflow dispatch
+```
+
+#### npm Scripts
+```bash
+# Available accessibility testing commands:
+npm run test:accessibility  # Full accessibility test suite
+npm run test:a11y          # Shorthand command
+```
+
+#### Git Hooks Integration
+- **Pre-commit Hook**: Quick accessibility validation before commits
+- **Post-merge Hook**: Reminder to run accessibility tests after merges
+
+### Setting Up Automation (One-time Setup)
+```bash
+# Run the automated setup script
+./setup-accessibility-automation.sh
+
+# Or manually set up Git hooks
+./setup-git-hooks.sh
+```
+
+### Code Review Checklist
+- [ ] **Semantic HTML**: Proper use of headings, landmarks, and semantic elements
+- [ ] **ARIA Attributes**: Correct implementation of ARIA labels and roles
+- [ ] **Keyboard Navigation**: All interactive elements accessible via keyboard
+- [ ] **Focus Management**: Logical focus order and visible focus indicators
+- [ ] **Color Accessibility**: Sufficient contrast ratios and no color-only information
+
+### Pre-Deployment Testing
+```bash
+# Automated accessibility test suite
+npm run test:accessibility
+
+# Or run the comprehensive script directly
+./test-accessibility.sh
+
+# Verify zero errors before deployment
+echo "✅ All accessibility tests must pass before deployment"
+```
+
+### CI/CD Integration Details
+
+#### GitHub Actions Workflow
+The automated testing workflow:
+1. **Triggers**: On push/PR to main branches
+2. **Environment Setup**: Node.js, dependencies, build
+3. **Server Start**: Launches development server
+4. **Test Execution**: Runs pa11y, Lighthouse, and axe-core tests
+5. **Results Analysis**: Checks for violations and generates reports
+6. **Artifact Storage**: Saves test results for 30 days
+7. **PR Comments**: Posts test results summary on pull requests
+8. **Build Status**: Fails build if accessibility violations found
+
+#### Automated Failure Thresholds
+- **Zero tolerance**: Any accessibility violations fail the build
+- **WCAG 2.1 AA**: All tests must pass WCAG 2.1 AA standards
+- **Comprehensive coverage**: Tests all main pages and user flows
+
+#### Notification and Reporting
+- **PR Comments**: Automated accessibility test results
+- **Build Status**: Pass/fail indicators in GitHub
+- **Detailed Reports**: Full test results in GitHub Actions artifacts
+- **Email Notifications**: GitHub settings control team notifications
+
+### Git Hooks Integration
+```bash
+# Pre-commit hook behavior:
+- Checks if development server is running
+- Runs quick pa11y test on homepage
+- Allows commit if no violations found
+- Provides helpful error messages and suggestions
+
+# Post-merge hook behavior:
+- Reminds developers to run full accessibility tests
+- Suggests running npm run test:accessibility
+```
+
+### Troubleshooting Automated Testing
+
+#### Common Issues and Solutions
+
+**Build Failing Due to Accessibility Violations:**
+```bash
+# 1. Run tests locally to reproduce
+npm run test:accessibility
+
+# 2. Review detailed reports in accessibility-test-results/
+open accessibility-test-results/accessibility-summary.html
+
+# 3. Fix violations following WCAG 2.1 AA guidelines
+# 4. Re-run tests to verify fixes
+# 5. Commit and push fixed code
+```
+
+**Pre-commit Hook Issues:**
+```bash
+# If pre-commit hook fails:
+# 1. Ensure development server is running
+npm start
+
+# 2. Run accessibility test manually
+npm run test:accessibility
+
+# 3. Fix any violations found
+# 4. Try committing again
+
+# To skip hook temporarily (not recommended):
+git commit --no-verify
+```
+
+**GitHub Actions Workflow Issues:**
+```bash
+# Check workflow status at:
+https://github.com/[username]/portfolio_v2/actions
+
+# Common fixes:
+# 1. Ensure all dependencies are in package.json
+# 2. Verify test-accessibility.sh has correct permissions
+# 3. Check for any new accessibility violations
+```
+
+### Monitoring and Maintenance
+
+#### Weekly Automated Checks
+- [ ] **CI/CD Status**: Verify GitHub Actions are running successfully
+- [ ] **Dependency Updates**: Check for updates to testing tools
+- [ ] **Hook Functionality**: Ensure Git hooks are working correctly
+
+#### Monthly Automation Review
+- [ ] **Workflow Performance**: Monitor test execution times
+- [ ] **False Positives**: Review any recurring test issues
+- [ ] **Tool Updates**: Update pa11y, Lighthouse, axe-core as needed
+- [ ] **Coverage Analysis**: Ensure all important pages are tested
+
+#### Automation Metrics
+- **Test Success Rate**: Percentage of builds passing accessibility tests
+- **Average Fix Time**: Time from violation detection to resolution
+- **Coverage Metrics**: Number of pages/components tested automatically
+- **Developer Adoption**: Usage of accessibility testing commands
+
+## Issue Management
+
+### Severity Classification
+
+#### Critical (Fix within 24 hours)
+- **Complete Blocking**: Core functionality inaccessible to users with disabilities
+- **Keyboard Traps**: Users cannot escape from interface elements
+- **Missing Focus**: No visible focus indicators on interactive elements
+- **Broken Screen Reader**: Content completely unreadable by assistive technology
+
+#### High (Fix within 3 business days)
+- **Navigation Issues**: Significant keyboard navigation problems
+- **Contrast Failures**: Text below WCAG AA contrast ratios
+- **Missing Labels**: Form inputs without proper labels
+- **Heading Structure**: Broken heading hierarchy affecting navigation
+
+#### Medium (Fix within 1 week)
+- **Enhancement Opportunities**: Areas for improved accessibility
+- **Minor Navigation**: Small improvements to keyboard navigation
+- **Content Clarity**: Text that could be clearer for screen readers
+- **Alternative Access**: Providing additional ways to access content
+
+#### Low (Address in next development cycle)
+- **AAA Compliance**: Exceeding AA requirements
+- **User Experience**: General usability improvements
+- **Documentation**: Updating accessibility documentation
+- **Tool Updates**: Upgrading accessibility testing tools
+
+### Issue Tracking Template
+```markdown
+## Accessibility Issue Report
+
+**Severity**: [Critical/High/Medium/Low]
+**Page/Component**: [URL or component name]
+**Issue Type**: [Keyboard/Screen Reader/Visual/Other]
+
+### Description
+[Detailed description of the accessibility issue]
+
+### Steps to Reproduce
+1. [Step one]
+2. [Step two]
+3. [Expected vs actual behavior]
+
+### Assistive Technology Used
+- **Screen Reader**: [NVDA/JAWS/VoiceOver/None]
+- **Browser**: [Chrome/Firefox/Safari/Edge + version]
+- **OS**: [Windows/macOS/iOS/Android + version]
+
+### Success Criteria
+[How will we know this issue is resolved?]
+
+### Testing Notes
+[Additional context for testing the fix]
+```
+
+## Tool Maintenance
+
+### Keeping Tools Updated
+```bash
+# Update global accessibility tools
+npm update -g pa11y lighthouse axe-core
+
+# Update project dependencies
+npm update
+
+# Verify tool versions
+pa11y --version
+lighthouse --version
+```
+
+### Tool Configuration Updates
+- **pa11y**: Update rules and standards as needed
+- **Lighthouse**: Keep pace with Google's accessibility updates
+- **axe-core**: Monitor for new accessibility rules
+
+### Alternative Tools
+- **WAVE**: Web-based accessibility checker
+- **Accessibility Insights**: Microsoft's accessibility testing tools
+- **Colour Contrast Analyser**: Desktop color contrast tool
+
+## Content Guidelines
+
+### Writing Accessible Content
+- **Clear Language**: Use simple, clear language appropriate for the audience
+- **Heading Structure**: Maintain logical heading hierarchy (H1 → H2 → H3)
+- **Link Text**: Make link text descriptive and meaningful out of context
+- **Lists**: Use proper list markup for grouped information
+
+### Image Accessibility
+- **Alt Text**: Provide concise, descriptive alt text for informative images
+- **Decorative Images**: Use empty alt="" for purely decorative images
+- **Complex Images**: Provide detailed descriptions for charts, graphs, or complex visuals
+- **Text in Images**: Avoid text in images; use real text with CSS styling
+
+### Form Accessibility
+- **Labels**: Associate every form input with a descriptive label
+- **Instructions**: Provide clear instructions and format requirements
+- **Error Messages**: Make error messages specific and helpful
+- **Required Fields**: Clearly mark required fields
+
+## Performance and Accessibility
+
+### Balancing Performance with Accessibility
+- **Image Optimization**: Compress images while maintaining quality for screen readers
+- **Code Splitting**: Ensure accessibility features load with initial page bundle
+- **Progressive Enhancement**: Core accessibility works without JavaScript
+- **Loading States**: Provide accessible loading indicators
+
+### Monitoring Performance Impact
+- **Bundle Size**: Monitor impact of accessibility-related JavaScript
+- **Lighthouse Scores**: Balance performance and accessibility scores
+- **Core Web Vitals**: Ensure accessibility features don't negatively impact performance
+
+## Team Training and Knowledge
+
+### Essential Knowledge Areas
+- **WCAG Guidelines**: Understanding of WCAG 2.1 AA requirements
+- **Assistive Technology**: Basic knowledge of how screen readers work
+- **Testing Methods**: Familiarity with automated and manual testing
+- **Legal Requirements**: Understanding of accessibility law compliance
+
+### Training Resources
+- **WebAIM**: Comprehensive accessibility training materials
+- **Deque University**: Professional accessibility courses
+- **A11y Project**: Community-driven accessibility resources
+- **Conference Talks**: AccessibilityConf, CSUN, and other accessibility events
+
+### Knowledge Sharing
+- **Code Reviews**: Include accessibility discussion in code reviews
+- **Team Meetings**: Regular accessibility updates and discussions
+- **Documentation**: Maintain internal accessibility knowledge base
+- **External Sharing**: Blog posts or talks about accessibility implementation
+
+## Compliance Monitoring
+
+### Regular Compliance Checks
+- **Automated Monitoring**: Set up automated accessibility testing in CI/CD
+- **User Feedback**: Monitor and respond to accessibility feedback
+- **Legal Updates**: Stay informed about accessibility law changes
+- **Standard Updates**: Monitor WCAG and other standard updates
+
+### Documentation Maintenance
+- **Accessibility Statement**: Keep current with actual site capabilities
+- **Testing Records**: Maintain records of accessibility testing and fixes
+- **Compliance Evidence**: Document evidence of accessibility compliance
+- **User Feedback**: Track and document response to accessibility feedback
+
+## Emergency Response
+
+### Critical Accessibility Issues
+1. **Immediate Assessment**: Determine scope and impact of the issue
+2. **Temporary Fix**: Implement quick fix if possible while working on permanent solution
+3. **User Communication**: Notify users of issue and expected resolution time
+4. **Permanent Resolution**: Implement comprehensive fix and test thoroughly
+5. **Post-Incident Review**: Analyze how the issue occurred and prevent recurrence
+
+### Communication Templates
+
+#### Issue Acknowledgment
+```
+Thank you for reporting this accessibility issue. We take accessibility very seriously and are investigating the problem you've described. We will respond with our findings and resolution plan within [timeframe].
+```
+
+#### Resolution Notification
+```
+We have resolved the accessibility issue you reported on [date]. The fix has been deployed and tested. Please let us know if you continue to experience any difficulties accessing our content.
+```
+
+## Success Metrics
+
+### Key Performance Indicators
+- **Zero Critical Issues**: Maintain zero critical accessibility issues
+- **Response Time**: Average time to respond to accessibility feedback
+- **Resolution Time**: Average time to resolve accessibility issues
+- **User Satisfaction**: Positive feedback from users with disabilities
+
+### Monitoring Tools
+- **Analytics**: Monitor usage patterns from assistive technology users
+- **Feedback Tracking**: Systematic tracking of accessibility feedback
+- **Testing Coverage**: Percentage of site regularly tested for accessibility
+- **Tool Compliance**: Consistent passing scores on automated testing tools
+
+---
+
+**Document Version**: 1.0  
+**Last Updated**: June 15, 2025  
+**Next Review**: September 15, 2025  
+**Owner**: Development Team  
+**Contact**: accessibility@kainenwhite.com

--- a/migration/portfolio_v2.5/ACCESSIBILITY_STATEMENT.md
+++ b/migration/portfolio_v2.5/ACCESSIBILITY_STATEMENT.md
@@ -1,0 +1,152 @@
+# Accessibility Statement
+
+## Our Commitment to Accessibility
+
+This portfolio website is committed to ensuring digital accessibility for people with disabilities. We continually improve the user experience for everyone and apply the relevant accessibility standards to ensure we provide equal access to all users.
+
+## Conformance Status
+
+This website is **fully compliant** with the **Web Content Accessibility Guidelines (WCAG) 2.1 Level AA**. These guidelines explain how to make web content more accessible to people with disabilities, and user friendly for everyone.
+
+### Standards Compliance
+
+Our website meets the following accessibility standards:
+
+- **WCAG 2.1 AA** - Full compliance achieved
+- **Section 508** - Compliant through WCAG 2.1 AA conformance
+- **ADA (Americans with Disabilities Act)** - Compliant through web accessibility best practices
+
+## Accessibility Features
+
+### Visual Accessibility
+- **High Contrast Colors**: All text meets or exceeds WCAG 2.1 AA contrast ratios (4.5:1 minimum)
+- **Scalable Text**: Content remains readable and functional when text is scaled up to 200%
+- **Clear Visual Design**: Consistent layout and navigation patterns throughout the site
+- **Color Independence**: Information is not conveyed through color alone
+
+### Keyboard Accessibility
+- **Full Keyboard Navigation**: All interactive elements are accessible via keyboard
+- **Logical Tab Order**: Sequential navigation follows content structure
+- **Visible Focus Indicators**: Clear visual indicators for focused elements
+- **Skip Links**: Quick navigation to main content areas
+
+### Screen Reader Compatibility
+- **Semantic HTML**: Proper heading structure and landmarks
+- **Alternative Text**: Descriptive alt text for all informative images
+- **ARIA Labels**: Enhanced accessibility labels where needed
+- **Structured Content**: Logical reading order and content hierarchy
+
+### Motion and Animation
+- **Reduced Motion Support**: Respects user preferences for reduced motion
+- **Essential Motion Only**: Animations serve functional purposes
+- **No Seizure-Inducing Content**: No flashing or rapidly changing content
+
+## Assistive Technology Compatibility
+
+This website has been designed to work with:
+
+- **Screen Readers**: NVDA, JAWS, VoiceOver, and other screen reading software
+- **Voice Recognition Software**: Dragon NaturallySpeaking and similar tools
+- **Screen Magnification Software**: ZoomText and built-in browser zoom
+- **Alternative Input Devices**: Switch navigation, eye-tracking, and other assistive devices
+
+## Browser and Device Support
+
+Our accessibility features work across:
+
+### Browsers
+- Chrome (latest 2 versions)
+- Firefox (latest 2 versions)
+- Safari (latest 2 versions)
+- Edge (latest 2 versions)
+
+### Devices
+- Desktop computers
+- Laptops
+- Tablets
+- Mobile phones
+
+## Keyboard Navigation Guide
+
+### Essential Keyboard Shortcuts
+- **Tab**: Navigate forward through interactive elements
+- **Shift + Tab**: Navigate backward through interactive elements
+- **Enter/Space**: Activate buttons and links
+- **Escape**: Close modals and return to previous state
+- **Arrow Keys**: Navigate within menus and carousels
+
+### Navigation Landmarks
+- **Skip to Main Content**: Available via Tab key on page load
+- **Header Navigation**: Logo, main menu, and contact button
+- **Main Content**: Primary page content area
+- **Footer**: Additional links and information
+
+## Testing and Validation
+
+This website undergoes regular accessibility testing using:
+
+### Automated Testing Tools
+- **pa11y**: Command-line accessibility testing
+- **Lighthouse**: Google's accessibility audit tool
+- **axe-core**: Industry-standard accessibility testing engine
+
+### Testing Results
+- **0 accessibility violations** across all pages
+- **100% WCAG 2.1 AA compliance** maintained
+- **Regular testing schedule** to ensure continued compliance
+
+## Known Limitations
+
+Currently, there are no known accessibility limitations on this website. All features and content are fully accessible to users with disabilities.
+
+## Feedback and Contact
+
+We welcome feedback on the accessibility of this portfolio website. If you encounter any accessibility barriers or have suggestions for improvement, please contact us:
+
+### Contact Information
+- **Email**: [contact@kainenwhite.com](mailto:contact@kainenwhite.com)
+- **Response Time**: We aim to respond to accessibility feedback within 2 business days
+- **Resolution Time**: We will work to address accessibility issues within 5 business days
+
+### What to Include in Your Feedback
+- **Page URL**: Where you encountered the issue
+- **Description**: What accessibility barrier you experienced
+- **Assistive Technology**: What tools you were using (if applicable)
+- **Browser and Device**: Your technical setup
+
+## Technical Specifications
+
+### Accessibility Standards
+- **WCAG Version**: 2.1
+- **Conformance Level**: AA (Full Compliance)
+- **Last Updated**: June 15, 2025
+- **Next Review**: December 15, 2025
+
+### Technologies Used
+- **HTML5**: Semantic markup for proper structure
+- **CSS3**: Accessible styling and responsive design
+- **JavaScript (React)**: Progressive enhancement with accessibility in mind
+- **ARIA**: Accessible Rich Internet Applications attributes where needed
+
+## Continuous Improvement
+
+We are committed to maintaining and improving the accessibility of this website. Our ongoing efforts include:
+
+- **Regular Accessibility Audits**: Quarterly testing and validation
+- **Standards Updates**: Staying current with evolving accessibility guidelines
+- **User Feedback Integration**: Incorporating accessibility suggestions from real users
+- **Technology Updates**: Ensuring new features maintain accessibility standards
+
+## Additional Resources
+
+For more information about web accessibility:
+
+- [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/WAI/WCAG21/quickref/)
+- [WebAIM: Web Accessibility In Mind](https://webaim.org/)
+- [A11y Project: Community-driven accessibility resources](https://www.a11yproject.com/)
+
+---
+
+**Last Updated**: June 15, 2025  
+**Compliance Status**: WCAG 2.1 AA Compliant  
+**Contact**: contact@kainenwhite.com

--- a/migration/portfolio_v2.5/ACCESSIBILITY_TESTING_CHECKLIST.md
+++ b/migration/portfolio_v2.5/ACCESSIBILITY_TESTING_CHECKLIST.md
@@ -1,0 +1,219 @@
+# Accessibility Testing Checklist
+
+## Overview
+This checklist ensures ongoing WCAG 2.1 AA compliance for the portfolio website. Use this document for regular accessibility audits and before deploying any changes.
+
+## Automated Testing Tools
+
+### Required Tools
+- **pa11y**: `npm install -g pa11y`
+- **Lighthouse**: Built into Chrome DevTools or `npm install -g lighthouse`
+- **axe DevTools**: Browser extension for Chrome/Firefox
+
+### Running Automated Tests
+
+#### pa11y Testing
+```bash
+# Install pa11y globally
+npm install -g pa11y
+
+# Test individual pages
+pa11y http://localhost:3000
+pa11y http://localhost:3000/about
+pa11y http://localhost:3000/projects
+pa11y http://localhost:3000/contact
+
+# Generate reports
+pa11y --reporter html http://localhost:3000 > pa11y-home.html
+```
+
+#### Lighthouse Testing
+```bash
+# Install Lighthouse globally
+npm install -g lighthouse
+
+# Run accessibility audit
+lighthouse http://localhost:3000 --only-categories=accessibility --output=html --output-path=lighthouse-accessibility.html
+```
+
+#### Project-Specific Testing Script
+```bash
+# Use the existing test script
+./test-accessibility.sh
+```
+
+## Manual Testing Checklist
+
+### ✅ Keyboard Navigation Testing
+
+#### Basic Navigation
+- [ ] **Tab Order**: Sequential and logical tab order through all interactive elements
+- [ ] **Focus Indicators**: Visible focus indicators on all interactive elements
+- [ ] **Skip Links**: "Skip to main content" link appears and functions on Tab
+- [ ] **Trapped Focus**: Focus remains within modals when open
+- [ ] **Return Focus**: Focus returns to trigger element when modals close
+
+#### Navigation Elements
+- [ ] **Header Navigation**: All links accessible via keyboard
+- [ ] **Main Menu**: Can navigate entire menu with keyboard only
+- [ ] **Footer Links**: All footer links reachable and functional
+- [ ] **CTA Buttons**: All call-to-action buttons activate with Enter/Space
+- [ ] **Form Elements**: All inputs, buttons, and form controls accessible
+
+#### Interactive Components
+- [ ] **Project Cards**: Can navigate and activate project links
+- [ ] **Contact Form**: Complete form submission possible with keyboard only
+- [ ] **Theme Toggle**: Theme switching works with keyboard
+- [ ] **Tab Switches**: Project/design tabs work with arrow keys or Enter
+
+### ✅ Screen Reader Testing
+
+#### Content Structure
+- [ ] **Headings**: Logical heading hierarchy (H1 → H2 → H3)
+- [ ] **Landmarks**: Page regions properly identified (header, nav, main, footer)
+- [ ] **Lists**: Lists properly marked up and announced
+- [ ] **Tables**: Data tables have proper headers and captions (if any)
+
+#### Images and Media
+- [ ] **Alt Text**: All informative images have descriptive alt text
+- [ ] **Decorative Images**: Decorative images have empty alt="" or aria-hidden="true"
+- [ ] **Icons**: Icons have proper labels or are marked as decorative
+- [ ] **Complex Images**: Charts/diagrams have detailed descriptions
+
+#### Interactive Elements
+- [ ] **Links**: Link purposes are clear from context or aria-label
+- [ ] **Buttons**: Button functions are clear and descriptive
+- [ ] **Form Labels**: All form inputs have associated labels
+- [ ] **Error Messages**: Form errors are announced and associated with inputs
+
+### ✅ Visual and Zoom Testing
+
+#### Text and Contrast
+- [ ] **Text Scaling**: Content readable and functional at 200% zoom
+- [ ] **Contrast Ratios**: All text meets 4.5:1 contrast minimum
+- [ ] **Color Dependency**: Information not conveyed by color alone
+- [ ] **Text Spacing**: Text remains readable with custom spacing
+
+#### Layout and Responsive Design
+- [ ] **Horizontal Scrolling**: No horizontal scrolling at 200% zoom
+- [ ] **Content Reflow**: Content reflows properly at different zoom levels
+- [ ] **Mobile Accessibility**: Touch targets at least 44px × 44px
+- [ ] **Responsive Navigation**: Navigation remains accessible on all screen sizes
+
+### ✅ Motion and Animation Testing
+
+#### Animation Preferences
+- [ ] **Reduced Motion**: Respects `prefers-reduced-motion: reduce`
+- [ ] **Essential Animation**: Only essential animations remain with reduced motion
+- [ ] **No Seizure Risk**: No flashing content or rapidly changing elements
+- [ ] **Auto-play**: No auto-playing media without user control
+
+## Color Contrast Testing
+
+### Tools for Contrast Testing
+- **WebAIM Contrast Checker**: https://webaim.org/resources/contrastchecker/
+- **Colour Contrast Analyser**: Desktop application
+- **Browser DevTools**: Built-in contrast checking
+
+### Minimum Requirements
+- **Normal Text**: 4.5:1 contrast ratio minimum
+- **Large Text** (18pt+): 3:1 contrast ratio minimum
+- **UI Components**: 3:1 contrast ratio minimum
+- **Focus Indicators**: 3:1 contrast ratio minimum
+
+### Current Color Combinations to Test
+```css
+/* Light Theme */
+--text-color: #343A40 on --card-background: #FFFFFF ✅
+--primary-accent: #005A9C on --card-background: #FFFFFF ✅
+--cta-color: #007BFF on --card-background: #FFFFFF ✅
+
+/* Dark Theme */
+--text-color: #F7FAFC on --card-background: #171717 ✅
+--primary-accent: #2B6CB0 on --card-background: #171717 ✅
+--cta-color: #4299E1 on --card-background: #171717 ✅
+
+/* Fixed High-Contrast Elements */
+CTA Buttons: #000c16 background with #fff text ✅
+```
+
+## Browser and Device Testing
+
+### Supported Browsers
+- [ ] **Chrome** (latest 2 versions)
+- [ ] **Firefox** (latest 2 versions)
+- [ ] **Safari** (latest 2 versions)
+- [ ] **Edge** (latest 2 versions)
+
+### Device Testing
+- [ ] **Desktop**: Full functionality with mouse and keyboard
+- [ ] **Tablet**: Touch accessibility and responsive design
+- [ ] **Mobile**: Touch targets and mobile-specific interactions
+- [ ] **High DPI**: Content clarity on high-resolution displays
+
+## Assistive Technology Compatibility
+
+### Screen Readers
+- [ ] **VoiceOver** (macOS/iOS): Native Apple screen reader
+- [ ] **NVDA** (Windows): Free, open-source screen reader
+- [ ] **JAWS** (Windows): Professional screen reader
+- [ ] **TalkBack** (Android): Mobile screen reader
+
+### Other Assistive Technologies
+- [ ] **Voice Control**: Dragon NaturallySpeaking, Voice Control
+- [ ] **Switch Navigation**: Alternative input devices
+- [ ] **Screen Magnification**: ZoomText, built-in magnifiers
+- [ ] **High Contrast**: System high contrast modes
+
+## Regression Testing Workflow
+
+### Before Each Release
+1. **Run Automated Tests**: Execute full test suite
+2. **Spot Check Navigation**: Test keyboard navigation on key pages
+3. **Verify Contrast**: Confirm no new contrast issues
+4. **Test New Features**: Ensure new components meet accessibility standards
+
+### Quarterly Full Audit
+1. **Complete Manual Testing**: Full checklist execution
+2. **Assistive Technology Testing**: Test with actual screen readers
+3. **User Feedback Review**: Address any accessibility feedback received
+4. **Documentation Updates**: Update this checklist and accessibility statement
+
+## Issue Tracking and Resolution
+
+### Severity Levels
+- **Critical**: Blocks core functionality for users with disabilities
+- **High**: Significantly impacts user experience
+- **Medium**: Minor accessibility improvements
+- **Low**: Enhancement opportunities
+
+### Resolution Timeline
+- **Critical**: Fix within 24 hours
+- **High**: Fix within 3 business days
+- **Medium**: Fix within 1 week
+- **Low**: Address in next development cycle
+
+## Resources and Tools
+
+### Testing Tools
+- [pa11y](https://github.com/pa11y/pa11y) - Command line accessibility testing
+- [axe-core](https://github.com/dequelabs/axe-core) - Accessibility testing engine
+- [Lighthouse](https://developers.google.com/web/tools/lighthouse) - Google's audit tool
+- [WAVE](https://wave.webaim.org/) - Web accessibility evaluation tool
+
+### Reference Guides
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
+- [WebAIM Guidelines](https://webaim.org/)
+- [A11y Project Checklist](https://www.a11yproject.com/checklist/)
+- [MDN Accessibility Guide](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
+
+### Color and Design Tools
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+- [Colour Contrast Analyser](https://www.tpgi.com/color-contrast-checker/)
+- [Stark](https://www.getstark.co/) - Design accessibility plugin
+
+---
+
+**Document Version**: 1.0  
+**Last Updated**: June 15, 2025  
+**Next Review**: September 15, 2025

--- a/migration/portfolio_v2.5/KEYBOARD_NAVIGATION_GUIDE.md
+++ b/migration/portfolio_v2.5/KEYBOARD_NAVIGATION_GUIDE.md
@@ -1,0 +1,214 @@
+# Keyboard Navigation Guide
+
+## Overview
+This guide provides detailed keyboard navigation instructions for the portfolio website, ensuring full accessibility for users who rely on keyboard-only navigation.
+
+## Global Keyboard Shortcuts
+
+### Primary Navigation
+| Key | Action |
+|-----|--------|
+| `Tab` | Move forward through interactive elements |
+| `Shift + Tab` | Move backward through interactive elements |
+| `Enter` | Activate links and buttons |
+| `Space` | Activate buttons and checkboxes |
+| `Escape` | Close modals and return to previous state |
+
+### Page Navigation
+| Key | Action |
+|-----|--------|
+| `Tab` (first press) | Access "Skip to main content" link |
+| `Home` | Scroll to top of page |
+| `End` | Scroll to bottom of page |
+| `Page Up` | Scroll up one screen |
+| `Page Down` | Scroll down one screen |
+
+## Page-by-Page Navigation
+
+### Homepage (`/`)
+
+#### Navigation Order
+1. **Skip Link** → Main content skip link
+2. **Header Logo** → Return to homepage
+3. **Navigation Menu** → About, Projects, Contact links
+4. **Theme Toggle** → Switch between light/dark themes
+5. **Header CTA** → Contact button
+6. **Hero Section** → Main heading and description
+7. **CTA Buttons** → "View My Work" and "Download Resume"
+8. **Metrics Section** → Performance statistics
+9. **Featured Projects** → Project cards with action buttons
+10. **Footer** → Additional links and information
+
+#### Key Interactions
+- **Project Cards**: Use `Tab` to navigate to "Case Study" buttons, `Enter` to activate
+- **Download Resume**: `Enter` or `Space` to download PDF
+- **Theme Toggle**: `Enter` or `Space` to switch themes
+
+### About Page (`/about`)
+
+#### Navigation Order
+1. **Skip Link** → Main content access
+2. **Header Navigation** → Standard header elements
+3. **About Section** → Main content and personal information
+4. **Services Grid** → Service offerings and descriptions
+5. **Process Steps** → How I work methodology
+6. **Skills Section** → Technical capabilities
+7. **Footer** → Contact and additional links
+
+#### Key Interactions
+- **Service Cards**: Focus highlights entire card area
+- **Process Steps**: Sequential navigation through workflow
+- **Skill Tags**: Informational, no activation required
+
+### Projects Page (`/projects`)
+
+#### Navigation Order
+1. **Skip Link** → Main content access
+2. **Header Navigation** → Standard header elements
+3. **Tab Switcher** → Design/Development project categories
+4. **Project Grid** → Individual project cards
+5. **Project Actions** → Case study and live demo buttons
+6. **Footer** → Additional navigation
+
+#### Key Interactions
+- **Tab Switcher**: 
+  - `Tab` to focus switcher
+  - `Left/Right Arrow` or `Enter` to change categories
+- **Project Cards**: 
+  - `Tab` through card elements
+  - `Enter` on buttons to view case studies or live demos
+- **External Links**: Open in new tabs (announced by screen readers)
+
+### Contact Page (`/contact`)
+
+#### Navigation Order
+1. **Skip Link** → Main content access
+2. **Header Navigation** → Standard header elements
+3. **Contact Form** → Form fields and submission
+4. **Contact Information** → Alternative contact methods
+5. **Footer** → Standard footer navigation
+
+#### Key Interactions
+- **Form Fields**:
+  - `Tab` to move between fields
+  - Type to enter information
+  - `Enter` to submit form (when on submit button)
+- **Required Fields**: Marked with asterisk and announced by screen readers
+- **Error Messages**: Focus moves to first error field if validation fails
+
+### Case Study Pages (`/projects/case-study/[project]`)
+
+#### Navigation Order
+1. **Skip Link** → Main content access
+2. **Header Navigation** → Standard header elements
+3. **Back Button** → Return to projects page
+4. **Case Study Content** → Detailed project information
+5. **Project Images** → Visual examples and screenshots
+6. **Technology Tags** → Technical implementation details
+7. **Footer** → Standard footer navigation
+
+#### Key Interactions
+- **Back Button**: `Enter` to return to projects page
+- **Image Gallery**: `Tab` through images, descriptions available to screen readers
+- **External Links**: Prototype links and live demos open in new tabs
+
+## Modal and Overlay Navigation
+
+### Contact Modal (when available)
+1. **Focus Trap**: Focus remains within modal
+2. **Close Button**: `Escape` or `Enter` on close button
+3. **Form Navigation**: Standard form keyboard navigation
+4. **Return Focus**: Focus returns to trigger element when closed
+
+### Image Overlays (if present)
+1. **Image Focus**: Large image receives focus
+2. **Navigation**: Arrow keys to navigate between images
+3. **Close**: `Escape` to close overlay
+4. **Return Focus**: Focus returns to triggering image
+
+## Focus Management
+
+### Focus Indicators
+- **Visible Outline**: Blue outline around focused elements
+- **High Contrast**: 3:1 contrast ratio minimum for focus indicators
+- **Consistent Style**: Same focus indicator style across all elements
+
+### Focus Behavior
+- **Logical Order**: Tab order follows visual reading order
+- **Skip Links**: Available for efficient navigation
+- **Focus Trapping**: Modal dialogs trap focus appropriately
+- **Focus Return**: Focus returns to logical position after interactions
+
+## Accessibility Features
+
+### Screen Reader Support
+- **Headings**: Proper heading hierarchy (H1 → H2 → H3)
+- **Landmarks**: Page regions identified (header, nav, main, footer)
+- **Alt Text**: Descriptive text for all informative images
+- **ARIA Labels**: Enhanced descriptions for complex interactions
+
+### Visual Indicators
+- **Current Page**: Active navigation items clearly marked
+- **Button States**: Hover and focus states visually distinct
+- **Form Validation**: Error states clearly marked and announced
+- **Loading States**: Progress indicators for form submissions
+
+## Browser-Specific Notes
+
+### Chrome/Edge
+- Standard keyboard navigation behavior
+- Focus indicators follow system preferences
+- Form autofill may affect tab order
+
+### Firefox
+- Slight differences in focus indicator styling
+- Tab navigation includes all focusable elements by default
+- Form validation messages may vary
+
+### Safari
+- Tab navigation may require "Full Keyboard Access" enabled in System Preferences
+- Focus indicators may appear differently
+- VoiceOver integration for enhanced accessibility
+
+## Mobile Keyboard Navigation
+
+### External Keyboards
+- Same keyboard shortcuts apply
+- Touch and keyboard navigation can be mixed
+- Focus indicators adapt to touch screen interaction
+
+### On-Screen Keyboards
+- Form navigation optimized for mobile keyboards
+- Input types optimized (email, tel, url)
+- Submit buttons accessible via keyboard "Go" button
+
+## Troubleshooting
+
+### Common Issues
+- **Focus Not Visible**: Check browser zoom level and focus indicator contrast
+- **Tab Order Unclear**: Use browser developer tools to trace tab sequence
+- **Buttons Not Activating**: Ensure `Enter` and `Space` both work for buttons
+- **Modal Focus Trapped**: Use `Escape` key or focus on close button
+
+### Browser Settings
+- **Chrome**: Enable "Navigate pages with a keyboard" in Accessibility settings
+- **Firefox**: Enable "Always use the cursor keys to navigate within pages"
+- **Safari**: Enable "Press Tab to highlight each item on a webpage"
+
+## Additional Resources
+
+### Screen Reader Testing
+- **VoiceOver** (macOS): `Cmd + F5` to enable
+- **NVDA** (Windows): Free download from nvaccess.org
+- **Browser Extensions**: axe DevTools, WAVE, or Lighthouse
+
+### Keyboard Navigation Tools
+- **Tab Order Visualization**: Browser developer tools
+- **Focus Management**: JavaScript debugging for complex interactions
+- **Accessibility Tree**: View how screen readers interpret the page
+
+---
+
+**Last Updated**: June 15, 2025  
+**Compatibility**: All modern browsers and assistive technologies  
+**Contact**: For navigation issues, contact accessibility@kainenwhite.com

--- a/migration/portfolio_v2.5/NEXTJS_ACCESSIBILITY_MIGRATION.md
+++ b/migration/portfolio_v2.5/NEXTJS_ACCESSIBILITY_MIGRATION.md
@@ -1,0 +1,149 @@
+# Next.js Accessibility Testing Migration Guide
+
+## 🔄 Migrating Accessibility Automation to Next.js
+
+### **Step 1: Update URLs in Test Configuration**
+
+Your current accessibility tests target these URLs:
+```javascript
+const urls = [
+    'http://localhost:3000',                    // → Same (Next.js default port)
+    'http://localhost:3000/about',              // → Same
+    'http://localhost:3000/projects',           // → Same
+    'http://localhost:3000/contact',            // → Same
+    'http://localhost:3000/projects/case-study/shopify-conversion-optimization'  // → Same
+];
+```
+
+**Good news**: Next.js uses the same default port (3000), so URLs remain unchanged!
+
+### **Step 2: Update npm Scripts for Next.js**
+
+```json
+{
+  "scripts": {
+    "dev": "next dev",                          // Replaces "start"
+    "build": "next build",                      // Enhanced build
+    "start": "next start",                      // Production server
+    "export": "next export",                    // Static export (if needed)
+    "test:accessibility": "./test-accessibility.sh",  // UNCHANGED
+    "test:a11y": "npm run test:accessibility",         // UNCHANGED
+    "precommit:accessibility": "npm run test:accessibility"  // UNCHANGED
+  }
+}
+```
+
+### **Step 3: Update GitHub Actions for Next.js**
+
+```yaml
+# .github/workflows/accessibility-testing.yml modifications
+- name: Install dependencies
+  run: npm ci
+
+- name: Build the application
+  run: npm run build                    # Next.js build
+
+- name: Start the application  
+  run: npm run start &                  # Next.js production server
+  env:
+    CI: true
+
+- name: Wait for application to be ready
+  run: |
+    echo "Waiting for Next.js application to start..."
+    npx wait-on http://localhost:3000 --timeout 60000
+```
+
+### **Step 4: Testing Script Compatibility**
+
+Your `test-accessibility.sh` script will work **unchanged** with Next.js because:
+- ✅ Same port (3000)
+- ✅ Same URL structure  
+- ✅ Same HTML output (React SSR → Next.js SSR)
+- ✅ Same accessibility testing tools (pa11y, Lighthouse, axe-core)
+
+### **Step 5: Enhanced Next.js Accessibility Features**
+
+Next.js provides additional accessibility benefits:
+```javascript
+// Enhanced SEO and accessibility with Next.js Head
+import Head from 'next/head'
+
+export default function Page() {
+  return (
+    <>
+      <Head>
+        <title>Accessible Page Title</title>
+        <meta name="description" content="Accessible description" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      {/* Your page content */}
+    </>
+  )
+}
+```
+
+### **Step 6: Migration Checklist**
+
+#### Files to Copy/Migrate:
+- ✅ `accessibility-test-config.js` → **Copy unchanged**
+- ✅ `test-accessibility.sh` → **Copy unchanged**  
+- ✅ `.github/workflows/accessibility-testing.yml` → **Minor updates**
+- ✅ `pre-commit-accessibility-hook.sh` → **Copy unchanged**
+- ✅ `setup-accessibility-automation.sh` → **Update npm scripts**
+- ✅ All accessibility documentation → **Copy unchanged**
+
+#### Testing Strategy:
+1. **Copy all accessibility files** to Next.js project
+2. **Update npm scripts** for Next.js commands
+3. **Test locally**: `npm run test:accessibility`  
+4. **Verify CI/CD**: Push to trigger GitHub Actions
+5. **Validate results**: Ensure same accessibility compliance
+
+### **Step 7: Next.js Specific Accessibility Enhancements**
+
+```javascript
+// next.config.js - Add accessibility-focused configurations
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Enhanced accessibility reporting
+  experimental: {
+    optimizeCss: true,        // Better CSS optimization
+    scrollRestoration: true,  // Accessible scroll behavior
+  },
+  // Image optimization for accessibility
+  images: {
+    domains: ['your-domain.com'],
+    formats: ['image/webp', 'image/avif'],
+  },
+  // Security headers for accessibility compliance
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+        ],
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig
+```
+
+## 🎯 **Result: Zero Disruption to Accessibility Testing**
+
+The beauty of your current accessibility automation is that it's **framework-agnostic**:
+- Tests the final HTML output (not React/Next.js internals)
+- Uses standard web URLs (not framework-specific routing)
+- Validates WCAG compliance regardless of underlying technology
+
+**Your accessibility automation will transfer seamlessly to Next.js!**

--- a/migration/portfolio_v2.5/accessibility-test-config.js
+++ b/migration/portfolio_v2.5/accessibility-test-config.js
@@ -1,0 +1,98 @@
+// Accessibility testing configuration
+module.exports = {
+  // URLs to test
+  urls: [
+    'http://localhost:3000',
+    'http://localhost:3000/about',
+    'http://localhost:3000/projects',
+    'http://localhost:3000/contact',
+    'http://localhost:3000/projects/case-study/shopify-conversion-optimization',
+    'http://localhost:3000/404-test' // 404 page
+  ],
+  
+  // pa11y configuration
+  pa11y: {
+    standard: 'WCAG2AA',
+    timeout: 30000,
+    chromeLaunchConfig: {
+      executablePath: undefined, // Use system Chrome
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-gpu'
+      ]
+    },
+    actions: [
+      'wait for element body to be visible'
+    ]
+  },
+
+  // Lighthouse configuration
+  lighthouse: {
+    extends: 'lighthouse:default',
+    settings: {
+      onlyCategories: ['accessibility'],
+      formFactor: 'desktop',
+      throttling: {
+        rttMs: 40,
+        throughputKbps: 10240,
+        cpuSlowdownMultiplier: 1
+      },
+      screenEmulation: {
+        mobile: false,
+        width: 1920,
+        height: 1080,
+        deviceScaleFactor: 1
+      }
+    }
+  },
+
+  // axe-core configuration
+  axe: {
+    tags: ['wcag2a', 'wcag2aa', 'wcag21aa'],
+    rules: {
+      'color-contrast': { enabled: true },
+      'focus-order-semantics': { enabled: true },
+      'keyboard-navigation': { enabled: true },
+      'aria-allowed-attr': { enabled: true },
+      'aria-required-children': { enabled: true },
+      'aria-required-parent': { enabled: true },
+      'aria-roles': { enabled: true },
+      'aria-valid-attr': { enabled: true },
+      'aria-valid-attr-value': { enabled: true },
+      'button-name': { enabled: true },
+      'bypass': { enabled: true },
+      'document-title': { enabled: true },
+      'duplicate-id': { enabled: true },
+      'form-field-multiple-labels': { enabled: true },
+      'frame-title': { enabled: true },
+      'html-has-lang': { enabled: true },
+      'html-lang-valid': { enabled: true },
+      'image-alt': { enabled: true },
+      'input-image-alt': { enabled: true },
+      'label': { enabled: true },
+      'landmark-banner-is-top-level': { enabled: true },
+      'landmark-contentinfo-is-top-level': { enabled: true },
+      'landmark-main-is-top-level': { enabled: true },
+      'landmark-no-duplicate-banner': { enabled: true },
+      'landmark-no-duplicate-contentinfo': { enabled: true },
+      'landmark-one-main': { enabled: true },
+      'link-name': { enabled: true },
+      'list': { enabled: true },
+      'listitem': { enabled: true },
+      'meta-refresh': { enabled: true },
+      'meta-viewport': { enabled: true },
+      'page-has-heading-one': { enabled: true },
+      'region': { enabled: true },
+      'scope-attr-valid': { enabled: true },
+      'server-side-image-map': { enabled: true },
+      'tabindex': { enabled: true },
+      'table-fake-caption': { enabled: true },
+      'td-headers-attr': { enabled: true },
+      'th-has-data-cells': { enabled: true },
+      'valid-lang': { enabled: true },
+      'video-caption': { enabled: true }
+    }
+  }
+};

--- a/migration/portfolio_v2.5/package.json
+++ b/migration/portfolio_v2.5/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:accessibility": "./test-accessibility.sh",
+    "test:a11y": "npm run test:accessibility",
+    "precommit:accessibility": "npm run test:accessibility"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/migration/portfolio_v2.5/test-accessibility.sh
+++ b/migration/portfolio_v2.5/test-accessibility.sh
@@ -1,0 +1,348 @@
+#!/bin/bash
+
+# Accessibility Testing Script
+# Runs comprehensive accessibility tests using pa11y, Lighthouse, and axe-core
+
+echo "🔍 Starting Comprehensive Accessibility Testing..."
+echo "=============================================="
+
+# Check if server is running
+if ! curl -s http://localhost:3000 > /dev/null; then
+    echo "❌ Error: Development server not running on port 3001"
+    echo "Please run 'npm run dev' in the Next.js project first"
+    exit 1
+fi
+
+echo "✅ Development server is running"
+
+# Create test results directory
+mkdir -p accessibility-test-results
+cd accessibility-test-results
+
+# Clear previous results
+rm -rf *
+
+echo ""
+echo "🧪 Running pa11y tests..."
+echo "========================"
+
+# URLs to test
+URLS=(
+    "http://localhost:3000"
+    "http://localhost:3000/about"
+    "http://localhost:3000/projects" 
+    "http://localhost:3000/contact"
+    "http://localhost:3000/projects/case-study/shopify-conversion-optimization"
+)
+
+# Run pa11y tests
+for url in "${URLS[@]}"; do
+    page_name=$(echo $url | sed 's|http://localhost:3000||' | sed 's|/|-|g' | sed 's|^-||')
+    if [ -z "$page_name" ]; then
+        page_name="home"
+    fi
+    
+    echo "Testing: $url"
+    npx pa11y --standard WCAG2AA --reporter html --timeout 30000 "$url" > "pa11y-${page_name}.html" 2>&1
+    npx pa11y --standard WCAG2AA --reporter json --timeout 30000 "$url" > "pa11y-${page_name}.json" 2>&1
+done
+
+echo ""
+echo "🔦 Running Lighthouse accessibility audits..."
+echo "============================================"
+
+# Run Lighthouse tests
+for url in "${URLS[@]}"; do
+    page_name=$(echo $url | sed 's|http://localhost:3000||' | sed 's|/|-|g' | sed 's|^-||')
+    if [ -z "$page_name" ]; then
+        page_name="home"
+    fi
+    
+    echo "Lighthouse testing: $url"
+    npx lighthouse "$url" \
+        --only-categories=accessibility \
+        --output=html \
+        --output=json \
+        --output-path="lighthouse-${page_name}" \
+        --chrome-flags="--headless --no-sandbox --disable-gpu" \
+        --quiet || true
+done
+
+echo ""
+echo "⚡ Running axe-core tests..."
+echo "=========================="
+
+# Create axe test script
+cat > axe-test.js << 'EOF'
+const { chromium } = require('playwright');
+const AxeBuilder = require('@axe-core/playwright').default;
+const fs = require('fs');
+
+const urls = [
+    'http://localhost:3000',
+    'http://localhost:3000/about',
+    'http://localhost:3000/projects',
+    'http://localhost:3000/contact',
+    'http://localhost:3000/projects/case-study/shopify-conversion-optimization'
+];
+
+async function runAxeTests() {
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext();
+    
+    for (const url of urls) {
+        const page = await context.newPage();
+        
+        try {
+            console.log(`Testing: ${url}`);
+            await page.goto(url, { waitUntil: 'networkidle' });
+            
+            const results = await new AxeBuilder({ page })
+                .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+                .analyze();
+            
+            const pageName = url.replace('http://localhost:3000', '') 
+                .replace(/\//g, '-')
+                .replace(/^-/, '') || 'home';
+            
+            fs.writeFileSync(`axe-${pageName}.json`, JSON.stringify(results, null, 2));
+            
+            // Generate HTML report
+            const htmlReport = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Axe Accessibility Report - ${pageName}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .violation { background: #ffebee; padding: 10px; margin: 10px 0; border-left: 4px solid #f44336; }
+        .pass { background: #e8f5e8; padding: 10px; margin: 10px 0; border-left: 4px solid #4caf50; }
+        .incomplete { background: #fff3e0; padding: 10px; margin: 10px 0; border-left: 4px solid #ff9800; }
+        .summary { background: #f5f5f5; padding: 15px; margin: 20px 0; border-radius: 5px; }
+        h1, h2 { color: #333; }
+        pre { background: #f5f5f5; padding: 10px; overflow-x: auto; }
+    </style>
+</head>
+<body>
+    <h1>Axe Accessibility Report: ${pageName.charAt(0).toUpperCase() + pageName.slice(1)}</h1>
+    <div class="summary">
+        <h2>Summary</h2>
+        <p><strong>URL:</strong> ${url}</p>
+        <p><strong>Violations:</strong> ${results.violations.length}</p>
+        <p><strong>Passes:</strong> ${results.passes.length}</p>
+        <p><strong>Incomplete:</strong> ${results.incomplete.length}</p>
+        <p><strong>Test Date:</strong> ${new Date().toLocaleString()}</p>
+    </div>
+    
+    ${results.violations.length > 0 ? `
+    <h2>Violations (${results.violations.length})</h2>
+    ${results.violations.map(violation => `
+        <div class="violation">
+            <h3>${violation.id}: ${violation.help}</h3>
+            <p><strong>Impact:</strong> ${violation.impact}</p>
+            <p><strong>Description:</strong> ${violation.description}</p>
+            <p><strong>Help URL:</strong> <a href="${violation.helpUrl}" target="_blank">${violation.helpUrl}</a></p>
+            <p><strong>Affected Elements:</strong> ${violation.nodes.length}</p>
+            ${violation.nodes.map(node => `
+                <div style="margin-left: 20px; background: #fafafa; padding: 10px; margin: 5px 0;">
+                    <strong>Target:</strong> <code>${node.target.join(', ')}</code><br>
+                    <strong>HTML:</strong> <code>${node.html}</code><br>
+                    ${node.failureSummary ? `<strong>Failure:</strong> ${node.failureSummary}` : ''}
+                </div>
+            `).join('')}
+        </div>
+    `).join('')}
+    ` : '<div class="pass"><h2>No Violations Found! 🎉</h2></div>'}
+    
+    ${results.incomplete.length > 0 ? `
+    <h2>Incomplete Tests (${results.incomplete.length})</h2>
+    <p>These tests could not be completed and may require manual verification:</p>
+    ${results.incomplete.map(incomplete => `
+        <div class="incomplete">
+            <h3>${incomplete.id}: ${incomplete.help}</h3>
+            <p>${incomplete.description}</p>
+        </div>
+    `).join('')}
+    ` : ''}
+    
+    <h2>Successful Tests (${results.passes.length})</h2>
+    <div class="pass">
+        <p>${results.passes.length} accessibility tests passed successfully.</p>
+        <details>
+            <summary>View passed tests</summary>
+            <ul>
+                ${results.passes.map(pass => `<li>${pass.id}: ${pass.help}</li>`).join('')}
+            </ul>
+        </details>
+    </div>
+</body>
+</html>`;
+            
+            fs.writeFileSync(`axe-${pageName}.html`, htmlReport);
+            
+        } catch (error) {
+            console.error(`Error testing ${url}:`, error.message);
+        } finally {
+            await page.close();
+        }
+    }
+    
+    await context.close();
+    await browser.close();
+    console.log('Axe tests completed!');
+}
+
+runAxeTests().catch(console.error);
+EOF
+
+# Install playwright if not available and run axe tests
+if command -v npx playwright &> /dev/null; then
+    node axe-test.js
+else
+    echo "Installing playwright for axe tests..."
+    npm install --save-dev playwright @axe-core/playwright
+    npx playwright install chromium
+    node axe-test.js
+fi
+
+echo ""
+echo "📊 Generating summary report..."
+echo "============================="
+
+# Generate summary report
+cat > accessibility-summary.html << 'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Accessibility Test Summary</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; line-height: 1.6; }
+        .header { background: #2196F3; color: white; padding: 20px; margin: -20px -20px 20px; }
+        .test-section { background: #f5f5f5; padding: 15px; margin: 20px 0; border-radius: 5px; }
+        .success { color: #4caf50; font-weight: bold; }
+        .warning { color: #ff9800; font-weight: bold; }
+        .error { color: #f44336; font-weight: bold; }
+        .file-list { background: white; padding: 10px; border-radius: 3px; }
+        .file-list a { display: block; padding: 5px; text-decoration: none; color: #2196F3; }
+        .file-list a:hover { background: #f0f0f0; }
+        h1, h2 { color: #333; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🔍 Accessibility Test Results</h1>
+        <p>Comprehensive WCAG 2.1 AA compliance testing report</p>
+        <p><strong>Test Date:</strong> <script>document.write(new Date().toLocaleString());</script></p>
+    </div>
+
+    <div class="test-section">
+        <h2>🧪 pa11y Test Results</h2>
+        <p>WCAG 2.1 AA automated accessibility testing using pa11y</p>
+        <div class="file-list">
+EOF
+
+# List pa11y files
+for file in pa11y-*.html; do
+    if [ -f "$file" ]; then
+        page_name=$(echo $file | sed 's/pa11y-//' | sed 's/.html//' | sed 's/-/ /g')
+        # Capitalize first letter in a compatible way
+        page_name_cap=$(echo "$page_name" | sed 's/\b\w/\U&/g')
+        echo "            <a href=\"$file\" target=\"_blank\">📄 ${page_name_cap} Page Report</a>" >> accessibility-summary.html
+    fi
+done
+
+cat >> accessibility-summary.html << 'EOF'
+        </div>
+    </div>
+
+    <div class="test-section">
+        <h2>🔦 Lighthouse Accessibility Audits</h2>
+        <p>Google Lighthouse accessibility scoring and recommendations</p>
+        <div class="file-list">
+EOF
+
+# List lighthouse files
+for file in lighthouse-*.report.html; do
+    if [ -f "$file" ]; then
+        page_name=$(echo $file | sed 's/lighthouse-//' | sed 's/.report.html//' | sed 's/-/ /g')
+        # Capitalize first letter in a compatible way
+        page_name_cap=$(echo "$page_name" | sed 's/\b\w/\U&/g')
+        echo "            <a href=\"$file\" target=\"_blank\">💡 ${page_name_cap} Lighthouse Report</a>" >> accessibility-summary.html
+    fi
+done
+
+cat >> accessibility-summary.html << 'EOF'
+        </div>
+    </div>
+
+    <div class="test-section">
+        <h2>⚡ axe-core Test Results</h2>
+        <p>Detailed accessibility violations and compliance testing</p>
+        <div class="file-list">
+EOF
+
+# List axe files
+for file in axe-*.html; do
+    if [ -f "$file" ]; then
+        page_name=$(echo $file | sed 's/axe-//' | sed 's/.html//' | sed 's/-/ /g')
+        # Capitalize first letter in a compatible way
+        page_name_cap=$(echo "$page_name" | sed 's/\b\w/\U&/g')
+        echo "            <a href=\"$file\" target=\"_blank\">🔧 ${page_name_cap} Axe Report</a>" >> accessibility-summary.html
+    fi
+done
+
+cat >> accessibility-summary.html << 'EOF'
+        </div>
+    </div>
+
+    <div class="test-section">
+        <h2>📋 Manual Testing Checklist</h2>
+        <p>Additional manual tests recommended for complete WCAG 2.1 AA compliance:</p>
+        <ul>
+            <li>Screen reader testing (NVDA, JAWS, VoiceOver)</li>
+            <li>Keyboard-only navigation testing</li>
+            <li>Color contrast verification (minimum 4.5:1 for normal text)</li>
+            <li>Zoom testing up to 200% without horizontal scrolling</li>
+            <li>Focus indicator visibility and logical tab order</li>
+            <li>Form error handling and validation messages</li>
+            <li>Video/audio content accessibility (if applicable)</li>
+            <li>Animation and motion reduction preferences</li>
+        </ul>
+    </div>
+
+    <div class="test-section">
+        <h2>🎯 WCAG 2.1 AA Guidelines Covered</h2>
+        <ul>
+            <li><strong>Perceivable:</strong> Information and UI components must be presentable to users</li>
+            <li><strong>Operable:</strong> UI components and navigation must be operable</li>
+            <li><strong>Understandable:</strong> Information and operation of UI must be understandable</li>
+            <li><strong>Robust:</strong> Content must be robust enough for various assistive technologies</li>
+        </ul>
+    </div>
+
+    <footer style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #ddd; color: #666;">
+        <p>Generated automatically by accessibility testing suite</p>
+        <p>For questions about these results, please refer to the <a href="https://www.w3.org/WAI/WCAG21/quickref/" target="_blank">WCAG 2.1 Quick Reference</a></p>
+    </footer>
+</body>
+</html>
+EOF
+
+echo ""
+echo "✅ Accessibility testing completed!"
+echo "================================="
+echo ""
+echo "📊 Results saved in: accessibility-test-results/"
+echo "🌐 Open accessibility-summary.html to view all reports"
+echo ""
+echo "Quick access:"
+echo "- Summary Report: file://$(pwd)/accessibility-summary.html"
+echo "- pa11y Reports: pa11y-*.html"
+echo "- Lighthouse Reports: lighthouse-*.report.html" 
+echo "- Axe Reports: axe-*.html"
+echo ""
+echo "🎯 Next steps:"
+echo "1. Review all generated reports"
+echo "2. Address any violations found"
+echo "3. Perform manual testing checklist"
+echo "4. Re-run tests after fixes"


### PR DESCRIPTION
## Summary
- copy accessibility testing config, scripts, and docs into `migration/portfolio_v2.5`
- add accessibility test scripts to Next.js package.json
- run accessibility tests in CI workflow against the Next.js build

## Testing
- `npm run build` (fails: Failed to fetch fonts `Geist` and `Geist Mono`, Module not found: Can't resolve '../_Pages.css')


------
https://chatgpt.com/codex/tasks/task_e_689d881636f48333a873b4c4653f25ac