### PR TITLE
fix: remove premature context usage in layout

### DIFF
--- a/migration/portfolio_v2.5/src/app/layout.tsx
+++ b/migration/portfolio_v2.5/src/app/layout.tsx
@@ -1,35 +1,24 @@
-"use client";
-
 import "./globals.css";
 import "./_old-styles_/_Pages.css";
 import "./_old-styles_/Homepage.css";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { useContext, useEffect } from "react";
 import Header from "../Components/Header/Header";
 import Footer from "../Components/Footer/Footer";
 import ClientProvider from "../Components/ClientProvider";
-import { ThemeContext } from "../context/ThemeContext";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
 
-const metadata: Metadata = {
+export const metadata: Metadata = {
   title: "Kainen White | Product & UX Designer",
   description:
     "The design portfolio of Kainen White, a product and UX designer creating user-centered digital experiences that drive business growth. View case studies.",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const { theme } = useContext(ThemeContext);
-
-  // keep <html data-theme> in sync after hydration
-  useEffect(() => {
-    document.documentElement.setAttribute("data-theme", theme);
-  }, [theme]);
-
   return (
-    <html lang="en" data-theme={theme}>
+    <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ClientProvider>
           <a href="#main-content" className="skip-link">


### PR DESCRIPTION
## Summary
- fix RootLayout to avoid using ThemeContext before provider
- export metadata and simplify theme handling

## Testing
- `npm test` (missing script)
- `npm run lint` (fails: Using `<img>` could result in slower LCP..., React Hook "useEffect" is called conditionally., Unexpected any., A `require()` style import is forbidden., `'dialog' is assigned a value but never used.` and more)
- `npm run build` (fails: Failed to fetch font `Geist` and `Geist Mono`; Module not found: Can't resolve '../_Pages.css')
- `npm test` (No tests found related to files changed since last commit.)

------
https://chatgpt.com/codex/tasks/task_e_689d86b786708333814bdaba1f5d5d0a