### PR TITLE
Add react-router-dom dependency and replace Next.js router

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "pkg-dir": "^8.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
     "react-helmet-async": "^2.0.5",
     "react-scripts": "^5.0.1",
     "scheduler": "^0.26.0",

--- a/src/Components/Card/Card.js
+++ b/src/Components/Card/Card.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useRouter } from 'next/router';
+import { useNavigate } from 'react-router-dom';
 import './Card.css';
 import CTAButton from '../CTAButton/CTAButton';
 
 function Card({ image, title, description, actions = [], dataTestId }) {
-  const router = useRouter();
+  const navigate = useNavigate();
 
   return (
     <article className="project-card" data-testid={dataTestId}>
@@ -23,7 +23,7 @@ function Card({ image, title, description, actions = [], dataTestId }) {
                   key={idx}
                   variant="primary"
                   size="medium"
-                  onClick={() => router.push(action.href)}
+                  onClick={() => navigate(action.href)}
                   aria-label={`${action.label} for ${title}`}
                 >
                   {action.label}


### PR DESCRIPTION
## Summary
- add `react-router-dom` to dependencies
- use `useNavigate` from `react-router-dom` in Card component instead of Next.js router

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `npm run lint` *(fails: Cannot read config file /workspace/portfolio_v2/server/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e26b0f4788333b46ffae06b2361bd